### PR TITLE
Shared asset types

### DIFF
--- a/BingX.Net/BingX.Net.csproj
+++ b/BingX.Net/BingX.Net.csproj
@@ -53,12 +53,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CryptoExchange.Net" Version="12.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/BingX.Net/BingX.Net.csproj
+++ b/BingX.Net/BingX.Net.csproj
@@ -53,10 +53,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CryptoExchange.Net" Version="12.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/BingX.Net/Clients/PerpetualFuturesApi/BingXRestClientPerpetualFuturesApiShared.cs
+++ b/BingX.Net/Clients/PerpetualFuturesApi/BingXRestClientPerpetualFuturesApiShared.cs
@@ -86,7 +86,21 @@ namespace BingX.Net.Clients.PerpetualFuturesApi
             if (!result.Success)
                 return HttpResult.Fail<SharedFuturesSymbol[]>(result);
 
-            var resultData = result.Data.Where(x => !string.IsNullOrEmpty(x.Asset)).Select(s => new SharedFuturesSymbol(TradingMode.PerpetualLinear, s.Asset, s.Currency, s.Symbol, s.Status == 1)
+            var resultData = result.Data.Where(x => !string.IsNullOrEmpty(x.Asset)).Select(ParseSymbol);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.ToArray());
+            if (request.SymbolType != null)
+                resultData = resultData.Where(x => x.SymbolType == request.SymbolType);
+            if (request.SymbolSubType != null)
+                resultData = resultData.Where(x => x.SymbolSubType == request.SymbolSubType);
+
+            return HttpResult.Ok(result, resultData.ToArray());        
+                
+        }
+
+        private SharedFuturesSymbol ParseSymbol(BingXContract s)
+        {
+            var (symbolType, subType) = ParseSymbolType(s);
+            return new SharedFuturesSymbol(TradingMode.PerpetualLinear, s.Asset, s.Currency, s.Symbol, s.Status == 1)
             {
                 MinTradeQuantity = s.MinOrderQuantity,
                 MinNotionalValue = s.MinOrderValue,
@@ -94,13 +108,21 @@ namespace BingX.Net.Clients.PerpetualFuturesApi
                 QuantityDecimals = s.QuantityPrecision,
                 ContractSize = 1,
                 MaxShortLeverage = s.MaxShortLeverage,
-                MaxLongLeverage = s.MaxLongLeverage
-            }).ToArray();
+                MaxLongLeverage = s.MaxLongLeverage,
+                SymbolType = symbolType,
+                SymbolSubType = subType,
+                DisplayName = s.DisplayName
+            };
+        }
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData);
-            return HttpResult.Ok(result, resultData);
-        
-                
+        private (SymbolAssetType, SymbolAssetSubType?) ParseSymbolType(BingXContract s)
+        {
+            if (s.Symbol.StartsWith("NCSK"))
+                return (SymbolAssetType.Rwa, SymbolAssetSubType.Stock);
+            if (s.Symbol.StartsWith("NCCO"))
+                return (SymbolAssetType.Rwa, SymbolAssetSubType.Commodity);
+
+            return (SymbolAssetType.Crypto, null);
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)

--- a/BingX.Net/Clients/PerpetualFuturesApi/BingXRestClientPerpetualFuturesApiShared.cs
+++ b/BingX.Net/Clients/PerpetualFuturesApi/BingXRestClientPerpetualFuturesApiShared.cs
@@ -76,7 +76,7 @@ namespace BingX.Net.Clients.PerpetualFuturesApi
 
         #region Futures Symbol client
 
-        SharedSymbolCatalog? IFuturesSymbolRestClient.SymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
@@ -95,7 +95,6 @@ namespace BingX.Net.Clients.PerpetualFuturesApi
 
             ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, data);
             return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(data, request));
-
         }
 
         private SharedFuturesSymbol ParseSymbol(BingXContract s)
@@ -116,12 +115,12 @@ namespace BingX.Net.Clients.PerpetualFuturesApi
 
             if (s.Asset.StartsWith("NCSK"))
             {
-                result.BaseAssetType = SharedAssetType.Rwa;
+                result.BaseAssetType = SharedAssetType.TradFi;
                 result.BaseAssetSubType = SharedAssetSubType.Stock;
             }
             else if (s.Asset.StartsWith("NCCO"))
             {
-                result.BaseAssetType = SharedAssetType.Rwa;
+                result.BaseAssetType = SharedAssetType.TradFi;
                 result.BaseAssetSubType = SharedAssetSubType.Commodity;
             }
             else

--- a/BingX.Net/Clients/PerpetualFuturesApi/BingXRestClientPerpetualFuturesApiShared.cs
+++ b/BingX.Net/Clients/PerpetualFuturesApi/BingXRestClientPerpetualFuturesApiShared.cs
@@ -116,7 +116,7 @@ namespace BingX.Net.Clients.PerpetualFuturesApi
             if (s.Asset.StartsWith("NCSK"))
             {
                 result.BaseAssetType = SharedAssetType.TradFi;
-                result.BaseAssetSubType = SharedAssetSubType.Stock;
+                result.BaseAssetSubType = SharedAssetSubType.Equity;
             }
             else if (s.Asset.StartsWith("NCCO"))
             {

--- a/BingX.Net/Clients/PerpetualFuturesApi/BingXRestClientPerpetualFuturesApiShared.cs
+++ b/BingX.Net/Clients/PerpetualFuturesApi/BingXRestClientPerpetualFuturesApiShared.cs
@@ -6,6 +6,7 @@ using CryptoExchange.Net.Objects;
 using CryptoExchange.Net.Objects.Errors;
 using CryptoExchange.Net.SharedApis;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -75,6 +76,7 @@ namespace BingX.Net.Clients.PerpetualFuturesApi
 
         #region Futures Symbol client
 
+        SharedSymbolCatalog? IFuturesSymbolRestClient.SymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
@@ -86,21 +88,19 @@ namespace BingX.Net.Clients.PerpetualFuturesApi
             if (!result.Success)
                 return HttpResult.Fail<SharedFuturesSymbol[]>(result);
 
-            var resultData = result.Data.Where(x => !string.IsNullOrEmpty(x.Asset)).Select(ParseSymbol);
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.ToArray());
-            if (request.SymbolType != null)
-                resultData = resultData.Where(x => x.SymbolType == request.SymbolType);
-            if (request.SymbolSubType != null)
-                resultData = resultData.Where(x => x.SymbolSubType == request.SymbolSubType);
+            var data = result.Data
+                .Where(x => !string.IsNullOrEmpty(x.Asset))
+                .Select(x => ParseSymbol(x))
+                .ToArray();
 
-            return HttpResult.Ok(result, resultData.ToArray());        
-                
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, data);
+            return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(data, request));
+
         }
 
         private SharedFuturesSymbol ParseSymbol(BingXContract s)
         {
-            var (symbolType, subType) = ParseSymbolType(s);
-            return new SharedFuturesSymbol(TradingMode.PerpetualLinear, s.Asset, s.Currency, s.Symbol, s.Status == 1)
+            var result = new SharedFuturesSymbol(TradingMode.PerpetualLinear, s.Asset, s.Currency, s.Symbol, s.Status == 1)
             {
                 MinTradeQuantity = s.MinOrderQuantity,
                 MinNotionalValue = s.MinOrderValue,
@@ -109,20 +109,27 @@ namespace BingX.Net.Clients.PerpetualFuturesApi
                 ContractSize = 1,
                 MaxShortLeverage = s.MaxShortLeverage,
                 MaxLongLeverage = s.MaxLongLeverage,
-                SymbolType = symbolType,
-                SymbolSubType = subType,
+                QuoteAssetType = SharedAssetType.Crypto,
+                QuoteAssetSubType = LibraryHelpers.IsStableCoin(s.Currency) ? SharedAssetSubType.StableCoin : null,
                 DisplayName = s.DisplayName
             };
-        }
 
-        private (SymbolAssetType, SymbolAssetSubType?) ParseSymbolType(BingXContract s)
-        {
-            if (s.Symbol.StartsWith("NCSK"))
-                return (SymbolAssetType.Rwa, SymbolAssetSubType.Stock);
-            if (s.Symbol.StartsWith("NCCO"))
-                return (SymbolAssetType.Rwa, SymbolAssetSubType.Commodity);
+            if (s.Asset.StartsWith("NCSK"))
+            {
+                result.BaseAssetType = SharedAssetType.Rwa;
+                result.BaseAssetSubType = SharedAssetSubType.Stock;
+            }
+            else if (s.Asset.StartsWith("NCCO"))
+            {
+                result.BaseAssetType = SharedAssetType.Rwa;
+                result.BaseAssetSubType = SharedAssetSubType.Commodity;
+            }
+            else
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+            }
 
-            return (SymbolAssetType.Crypto, null);
+            return result;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)

--- a/BingX.Net/Clients/PerpetualFuturesApi/BingXRestClientPerpetualFuturesApiShared.cs
+++ b/BingX.Net/Clients/PerpetualFuturesApi/BingXRestClientPerpetualFuturesApiShared.cs
@@ -76,7 +76,7 @@ namespace BingX.Net.Clients.PerpetualFuturesApi
 
         #region Futures Symbol client
 
-        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {

--- a/BingX.Net/Clients/SpotApi/BingXRestClientSpotApiShared.cs
+++ b/BingX.Net/Clients/SpotApi/BingXRestClientSpotApiShared.cs
@@ -88,19 +88,44 @@ namespace BingX.Net.Clients.SpotApi
             if (!result.Success)
                 return HttpResult.Fail<SharedSpotSymbol[]>(result);
 
-            var resultData = result.Data.Select(s => new SharedSpotSymbol(s.Name.Split(new[] { '-' })[0], s.Name.Split(new[] { '-' })[1], s.Name, s.Status == SymbolStatus.Online)
+            var resultData = result.Data.Select(x => ParseSymbol(x)!).Where(x => x != null);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.ToArray());
+            if (request.SymbolType != null)
+                resultData = resultData.Where(x => x.SymbolType == request.SymbolType);
+            if (request.SymbolSubType != null)
+                resultData = resultData.Where(x => x.SymbolSubType == request.SymbolSubType);
+
+            return HttpResult.Ok(result, resultData.ToArray());
+        }
+
+        private SharedSpotSymbol? ParseSymbol(BingXSymbol s)
+        {
+            var assets = s.Name.Split(new[] { '-' });
+            if (assets.Length != 2)
+                return null;
+
+            var (symbolType, symbolSubType) = ParseSymbolType(assets[0]);
+            return new SharedSpotSymbol(assets[0], assets[1], s.Name, s.Status == SymbolStatus.Online)
             {
                 MinTradeQuantity = s.MinOrderQuantity,
                 MinNotionalValue = s.MinNotional,
                 MaxTradeQuantity = s.MaxOrderQuantity,
                 QuantityStep = s.StepSize,
-                PriceStep = s.TickSize
-            }).ToArray();
+                PriceStep = s.TickSize,
+                SymbolType = symbolType,
+                SymbolSubType = symbolSubType
+            };
+        }
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData);
-            return HttpResult.Ok(result, resultData);
-        
-                
+        private (SymbolAssetType, SymbolAssetSubType?) ParseSymbolType(string asset)
+        {
+            if (LibraryHelpers.IsStableCoin(asset))
+                return (SymbolAssetType.Crypto, SymbolAssetSubType.StableCoin);
+
+            if (LibraryHelpers.IsFiatAsset(asset))
+                return (SymbolAssetType.Fiat, null);
+
+            return (SymbolAssetType.Crypto, null);
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)

--- a/BingX.Net/Clients/SpotApi/BingXRestClientSpotApiShared.cs
+++ b/BingX.Net/Clients/SpotApi/BingXRestClientSpotApiShared.cs
@@ -81,7 +81,7 @@ namespace BingX.Net.Clients.SpotApi
 
         #region Spot Symbol client
 
-        SharedSymbolCatalog? ISpotSymbolRestClient.SymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {

--- a/BingX.Net/Clients/SpotApi/BingXRestClientSpotApiShared.cs
+++ b/BingX.Net/Clients/SpotApi/BingXRestClientSpotApiShared.cs
@@ -5,7 +5,10 @@ using CryptoExchange.Net;
 using CryptoExchange.Net.Objects;
 using CryptoExchange.Net.Objects.Errors;
 using CryptoExchange.Net.SharedApis;
+using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -22,6 +25,7 @@ namespace BingX.Net.Clients.SpotApi
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(BingXExchange.Metadata, this);
+        private static HashSet<string> _exchangeSupportedFiatCurrencies = ["EUR", "USD"];
 
         #region Kline client
 
@@ -77,6 +81,7 @@ namespace BingX.Net.Clients.SpotApi
 
         #region Spot Symbol client
 
+        SharedSymbolCatalog? ISpotSymbolRestClient.SymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
@@ -88,14 +93,13 @@ namespace BingX.Net.Clients.SpotApi
             if (!result.Success)
                 return HttpResult.Fail<SharedSpotSymbol[]>(result);
 
-            var resultData = result.Data.Select(x => ParseSymbol(x)!).Where(x => x != null);
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.ToArray());
-            if (request.SymbolType != null)
-                resultData = resultData.Where(x => x.SymbolType == request.SymbolType);
-            if (request.SymbolSubType != null)
-                resultData = resultData.Where(x => x.SymbolSubType == request.SymbolSubType);
+            var data = result.Data
+                .Select(x => ParseSymbol(x)!)
+                .Where(x => x != null)
+                .ToArray();
 
-            return HttpResult.Ok(result, resultData.ToArray());
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, data);
+            return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(data, request));
         }
 
         private SharedSpotSymbol? ParseSymbol(BingXSymbol s)
@@ -104,28 +108,89 @@ namespace BingX.Net.Clients.SpotApi
             if (assets.Length != 2)
                 return null;
 
-            var (symbolType, symbolSubType) = ParseSymbolType(assets[0]);
-            return new SharedSpotSymbol(assets[0], assets[1], s.Name, s.Status == SymbolStatus.Online)
+            var result = new SharedSpotSymbol(assets[0], assets[1], s.Name, s.Status == SymbolStatus.Online)
             {
                 MinTradeQuantity = s.MinOrderQuantity,
                 MinNotionalValue = s.MinNotional,
                 MaxTradeQuantity = s.MaxOrderQuantity,
                 QuantityStep = s.StepSize,
                 PriceStep = s.TickSize,
-                SymbolType = symbolType,
-                SymbolSubType = symbolSubType
+                DisplayName = s.DisplayName,
             };
+
+            if (LibraryHelpers.IsStableCoin(assets[0]))
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+                result.BaseAssetSubType = SharedAssetSubType.StableCoin;
+            } 
+            else if (_exchangeSupportedFiatCurrencies.Contains(assets[0]))
+            {
+                result.BaseAssetType = SharedAssetType.Fiat;
+            }
+            else
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+            }
+
+            if (LibraryHelpers.IsStableCoin(assets[1]))
+            {
+                result.QuoteAssetType = SharedAssetType.Crypto;
+                result.QuoteAssetSubType = SharedAssetSubType.StableCoin;
+            }
+            else if (_exchangeSupportedFiatCurrencies.Contains(assets[1]))
+            {
+                result.QuoteAssetType = SharedAssetType.Fiat;
+            }
+            else
+            {
+                result.QuoteAssetType = SharedAssetType.Crypto;
+            }
+
+            return result;
         }
 
-        private (SymbolAssetType, SymbolAssetSubType?) ParseSymbolType(string asset)
+
+        private SharedSymbolCatalog CreateCatalog(BingXSymbol[] bingXSymbols)
         {
-            if (LibraryHelpers.IsStableCoin(asset))
-                return (SymbolAssetType.Crypto, SymbolAssetSubType.StableCoin);
+            SharedAssetInfo MapAsset(string asset)
+            {
+                if (LibraryHelpers.IsStableCoin(asset))
+                    return new SharedAssetInfo(asset, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
 
-            if (LibraryHelpers.IsFiatAsset(asset))
-                return (SymbolAssetType.Fiat, null);
+                if (_exchangeSupportedFiatCurrencies.Contains(asset))
+                    return new SharedAssetInfo(asset, SharedAssetType.Fiat, null);
 
-            return (SymbolAssetType.Crypto, null);
+                return new SharedAssetInfo(asset, SharedAssetType.Crypto, null);
+            }
+
+            var assets = new Dictionary<string, SharedAssetInfo>();
+            var symbols = new Dictionary<string, SharedSymbolInfo>();
+            foreach (var symbol in bingXSymbols)
+            {
+                var symbolAssets = symbol.Name.Split(new[] { '-' });
+                if (symbolAssets.Length != 2)
+                    continue;
+
+                if (!assets.TryGetValue(symbolAssets[0], out var baseAssetInfo))
+                {
+                    baseAssetInfo = MapAsset(symbolAssets[0]);
+                    assets.Add(symbolAssets[0], baseAssetInfo);
+                }
+                if (!assets.TryGetValue(symbolAssets[1], out var quoteAssetInfo))
+                {
+                    quoteAssetInfo = MapAsset(symbolAssets[1]);
+                    assets.Add(symbolAssets[1], quoteAssetInfo);
+                }
+
+                symbols.Add(symbol.Name, new SharedSymbolInfo(symbol.Name, baseAssetInfo, quoteAssetInfo));
+            }
+
+            var catalog = new SharedSymbolCatalog
+            {
+                Assets = assets,
+                Symbols = symbols
+            };
+            return catalog;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)

--- a/BingX.Net/Clients/SpotApi/BingXRestClientSpotApiShared.cs
+++ b/BingX.Net/Clients/SpotApi/BingXRestClientSpotApiShared.cs
@@ -81,7 +81,7 @@ namespace BingX.Net.Clients.SpotApi
 
         #region Spot Symbol client
 
-        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
@@ -147,50 +147,6 @@ namespace BingX.Net.Clients.SpotApi
             }
 
             return result;
-        }
-
-
-        private SharedSymbolCatalog CreateCatalog(BingXSymbol[] bingXSymbols)
-        {
-            SharedAssetInfo MapAsset(string asset)
-            {
-                if (LibraryHelpers.IsStableCoin(asset))
-                    return new SharedAssetInfo(asset, SharedAssetType.Crypto, SharedAssetSubType.StableCoin);
-
-                if (_exchangeSupportedFiatCurrencies.Contains(asset))
-                    return new SharedAssetInfo(asset, SharedAssetType.Fiat, null);
-
-                return new SharedAssetInfo(asset, SharedAssetType.Crypto, null);
-            }
-
-            var assets = new Dictionary<string, SharedAssetInfo>();
-            var symbols = new Dictionary<string, SharedSymbolInfo>();
-            foreach (var symbol in bingXSymbols)
-            {
-                var symbolAssets = symbol.Name.Split(new[] { '-' });
-                if (symbolAssets.Length != 2)
-                    continue;
-
-                if (!assets.TryGetValue(symbolAssets[0], out var baseAssetInfo))
-                {
-                    baseAssetInfo = MapAsset(symbolAssets[0]);
-                    assets.Add(symbolAssets[0], baseAssetInfo);
-                }
-                if (!assets.TryGetValue(symbolAssets[1], out var quoteAssetInfo))
-                {
-                    quoteAssetInfo = MapAsset(symbolAssets[1]);
-                    assets.Add(symbolAssets[1], quoteAssetInfo);
-                }
-
-                symbols.Add(symbol.Name, new SharedSymbolInfo(symbol.Name, baseAssetInfo, quoteAssetInfo));
-            }
-
-            var catalog = new SharedSymbolCatalog
-            {
-                Assets = assets,
-                Symbols = symbols
-            };
-            return catalog;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)


### PR DESCRIPTION
Updated CryptoExchange.Net to v12.2.0 
Added SpotSymbolCatalog to Shared ISpotSymbolRestClient interface
Added FuturesSymbolCatalog to Shared IFuturesSymbolRestClient interface
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to GetSymbolsRequest model
Added DisplayName to SharedSpotSymbol and SharedFuturesSymbol models
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to SharedSpotSymbol and SharedFuturesSymbol models
Added DebuggerDisplay attributes to Shared models